### PR TITLE
Feature variable functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "exclude": [".git", ".gitignore", "travis.yml", "/tests", "phpunit.xml.dist"]
     },
     "require": {
-        "php": ">=7.0.0",
+        "php": ">=5.5.0",
         "guzzlehttp/guzzle": ">=6.1.0",
         "sabre/uri": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "exclude": [".git", ".gitignore", "travis.yml", "/tests", "phpunit.xml.dist"]
     },
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=7.0.0",
         "guzzlehttp/guzzle": ">=6.1.0",
         "sabre/uri": "^1.0"
     },

--- a/src/nester.php
+++ b/src/nester.php
@@ -4,9 +4,11 @@ namespace wrapi;
 
 class NestedDeco {
   protected $obj;
+    protected $func;
 
   function __construct() {
     $this->obj = new \stdClass();
+      $this->func = new \stdClass();
   }
 
   public function __set($name, $val) {
@@ -23,12 +25,18 @@ class NestedDeco {
   }
   
   public function __call($name, $args) {
-    if (property_exists($this->obj, $name) && is_callable($this->obj->$name)) {
+      if(is_callable($this->func->$name)){
+          return call_user_func_array($this->func->$name, $args);
+      }
+      throw new \RuntimeException('No such registered method. : '. $name);
+      return;
+      
+/*    if (property_exists($this->obj, $name) && is_callable($this->obj->$name)) {
         return call_user_func_array($this->obj->$name, $args);
     }
 
     throw new \RuntimeException('No such registered method. : '. $name);
-    return;
+    return;*/
   }
 
     public function setMethod($name, $func){

--- a/src/nester.php
+++ b/src/nester.php
@@ -30,4 +30,8 @@ class NestedDeco {
     throw new \RuntimeException('No such registered method. : '. $name);
     return;
   }
+
+    public function setMethod($name, $func){
+        $this->func->$name = $func;
+    }
 }

--- a/src/nester.php
+++ b/src/nester.php
@@ -30,13 +30,6 @@ class NestedDeco {
       }
       throw new \RuntimeException('No such registered method. : '. $name);
       return;
-      
-/*    if (property_exists($this->obj, $name) && is_callable($this->obj->$name)) {
-        return call_user_func_array($this->obj->$name, $args);
-    }
-
-    throw new \RuntimeException('No such registered method. : '. $name);
-    return;*/
   }
 
     public function setMethod($name, $func){

--- a/src/wrapi.php
+++ b/src/wrapi.php
@@ -145,7 +145,8 @@ class wrapi {
             $this->endpoints
         );
 
-        $tail->$last = $this->api($endpoint);
+//        $tail->$last = $this->api($endpoint);
+        $tail->setMethod($last, $this->api($endpoint));
 
         return $this;
     }


### PR DESCRIPTION
Until now, when property and method are the same character string as below, it was an error (RuntimeException, wrapi.php # 141).

``` 
{
 "get.test1":{
    "method": "GET",
    "path": "users"
  },
  "get.test1.test4":{
    "method": "GET",
    "path": "test4"
  }
}
```

I fixed it so that the error does not occur.
Added "$func" property and "setMethod" method to NestedDeco object.
Please confirm.

